### PR TITLE
Add hyper 0.11 support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ keywords = ["hyper", "dns"]
 license = "MIT"
 name = "hyper-dns"
 repository = "https://github.com/cswindle/hyper-dns"
-version = "0.2.2"
+version = "0.11.0"
 
 [badges]
 
@@ -14,10 +14,11 @@ repository = "cswindle/hyper-dns"
 
 [dependencies]
 futures = "0.1.14"
-hyper = "0.10.12"
+hyper = "0.11"
 log = "0.4.3"
 rand = "0.5.5"
-tokio = "0.1.8"
+tokio-core = "0.1.8"
+tokio-reactor = "0.1"
 
 [dependencies.trust-dns]
 default-features = false


### PR DESCRIPTION
I built this off of your hyper12 branch because it looked like it was closer to what I needed. `Connect` isn't a trait you implement in hyper 0.11, you implement `client::Service` instead. That's the bulk of the change.

Builds locally for me and I've tested that it works in our project.